### PR TITLE
Remove IVA submitted notification (GSI-1678)

### DIFF
--- a/src/nos/core/notifications.py
+++ b/src/nos/core/notifications.py
@@ -158,14 +158,6 @@ GHGA Data Portal.
 """,
 )
 
-IVA_CODE_SUBMITTED_TO_DS = Notification(
-    "IVA Verification Code Submitted",
-    """
-{full_user_name} has submitted an IVA verification code for review.
-
-The specified contact email address is: {email}.
-""",
-)
 
 IVA_UNVERIFIED_TO_USER = Notification(
     "Contact Address Invalidation",


### PR DESCRIPTION
There was a request to remove this notification since it was redundant and clogging the email inbox: [forum post](https://github.com/ghga-de/forum/discussions/54)

The version number is _not_ bumped because the previous PR bumped it and there hasn't been a release yet, so this PR will be lumped into the `6.1.0` release.

The notification this PR removes was for when a user submits their verification of an IVA. That's IVA state `VERIFIED` and the email subject "IVA Verification Code Submitted". The event type for the inbound kafka event is shared with the other IVA state updates, so the event subscriber is not touched. Only the core `Orchestrator` class was modified, and now will quietly ignore the IVA state change event if the state is `VERIFIED`. I added a regression test to double-check that consuming the event won't cause an error/DLQ event.